### PR TITLE
Removed comments before HTML doctype for IE8 standards mode

### DIFF
--- a/public_records_portal/templates/base.html
+++ b/public_records_portal/templates/base.html
@@ -1,6 +1,6 @@
-<!-- This template provides the header, footer, and envelope info for all pages except signup. -->
-
-<!doctype html>
+{#
+This template provides the header, footer, and envelope info for all pages except signup.
+#}<!doctype html>
 <html class="no-js" lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">

--- a/public_records_portal/templates/signup.html
+++ b/public_records_portal/templates/signup.html
@@ -1,5 +1,6 @@
-<!-- This template is for an interest signup. -->
-<!doctype html>
+{#
+This template is for an interest signup.
+#}<!doctype html>
 <html >
     <head>
 	    <meta http-equiv="X-UA-Compatible" content="chrome=1">

--- a/public_records_portal/templates/tutorial.html
+++ b/public_records_portal/templates/tutorial.html
@@ -1,18 +1,19 @@
-<!-- This template is for the tutorial. -->
+{#
+
+This template is for the tutorial.
+
+This template is for testing purposes.
+
+This template houses the baseline case information (request, documents, status, etc.) only.
+
+This template provides the header, footer, and envelope info for all pages except signup.
+
+#}<!doctype html>
 
 {% block custom_css_links %}
 <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/plugins/bootstro.css') }}">
 {% endblock custom_css_links %}
 
-
-
-<!-- This template is for testing purposes. -->
-
-<!-- This template houses the baseline case information (request, documents, status, etc.) only. -->
-
-<!-- This template provides the header, footer, and envelope info for all pages except signup. -->
-
-<!doctype html>
 <html class="no-js">
   <head>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">


### PR DESCRIPTION
[Persona says](https://developer.mozilla.org/docs/persona/Browser_compatibility#Internet_Explorer_.22Compatibility_Mode.22):

> Because versions of Internet Explorer earlier than 8.0 are not supported by Persona, any version of Internet Explorer which is configured to emulate a pre-8.0 version will also not function with Persona. This is typically for one of the following reasons:
> - your site is using "X-UA-Compatible" to explicitly instruct the browser to emulate a pre-8.0 version
> - your site's pages omit the DOCTYPE, do not have the DOCTYPE as the first line of the page, or set the browser to quirks mode, and your site is not setting "X-UA-Compatible" to IE version 8.0 or higher
> - the browser is locally configured to use a pre-8.0 Compatibility Mode, and your site is not overriding this by setting "X-UA-Compatible" to IE version 8.0 or higher
