### PR TITLE
Add update_user to the long import list

### DIFF
--- a/public_records_portal/prr.py
+++ b/public_records_portal/prr.py
@@ -11,7 +11,7 @@ import os, time, json
 from flask import Flask, request
 from flask.ext.login import current_user
 from datetime import datetime, timedelta
-from db_helpers import find_request, create_request, get_obj, add_staff_participant, remove_staff_participant, update_obj, get_attribute, change_request_status, create_or_return_user, create_subscriber, create_record, create_note, create_QA, create_answer
+from db_helpers import find_request, create_request, get_obj, add_staff_participant, remove_staff_participant, update_obj, get_attribute, change_request_status, create_or_return_user, create_subscriber, create_record, create_note, create_QA, create_answer, update_user
 from models import *
 from ResponsePresenter import ResponsePresenter
 from RequestPresenter import RequestPresenter


### PR DESCRIPTION
Without update_user in prr.py I saw the following:

```
$ heroku run python db_users.py
Running `python db_users.py` attached to terminal... up, run.4561
Traceback (most recent call last):
  File "db_users.py", line 4, in <module>
    set_directory_fields()
  File "/app/public_records_portal/prr.py", line 283, in set_directory_fields
    update_user(user = user, is_staff = False)
NameError: global name 'update_user' is not defined
$
```
