### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#RecordTrac
+# RecordTrac
 This is the home page for documentation for the **RecordTrac** application.
 
 * [What is RecordTrac](#what-is-recordtrac)
@@ -8,53 +8,53 @@ This is the home page for documentation for the **RecordTrac** application.
 
 For help contact [Code for America](http://www.codeforamerica.org/apps/recordtrac)
 
-##What is RecordTrac?
+## What is RecordTrac?
 RecordTrac is a public record request management tool for government agencies.
 ![RecordTrac](/docs/images/generic_request.png "RecordTrac")  
 This web application allows government employees manage, respond to, and fulfill incoming requests.  It also provides a quick, simple way for individuals to submit public record requests. RecordTrac displays all requests and responsive documents so that members of the public may find what they need without submitting additional public record requests.
 
 [More about RecordTrac...](/docs/about.md)
 
-##[How to create a new RecordTrac app for your agency](/docs/redeploy.md)
+## [How to create a new RecordTrac app for your agency](/docs/redeploy.md)
 * Groundwork
 * Best Practices
 * Redeploy on Heroku
 
-###To create a development environment, you can  [install RecordTrac locally](/docs/local_installation.md).
+### To create a development environment, you can  [install RecordTrac locally](/docs/local_installation.md).
 
-##Technical details
+## Technical details
 RecordTrac is primarily a Python application built on a backend Flask framework and a frontend Bootstrap framework.
 
 RecordTrac is compatible with most modern browsers, including Internet Explorer 8 and above.
 
-###Platform pieces
+### Platform pieces
 * [Flask 0.10](http://flask.pocoo.org/) is used as the backend Python framework.
 * [Bootstrap 2.3.2](http://getbootstrap.com/2.3.2) is used as the frontend HTML/CSS/JS framework.
 * [Postgres 9.3.0](http://www.postgresapp.com/) is used to manage the database.
 * [Python 2.7.5](http://www.python.org/getit) is used as the foundational programming language.
 
-###Plugins
+### Plugins
 * [Font Awesome 3.2.1](http://fortawesome.github.io/Font-Awesome) is used to render all the icons on the site.
 * A number of Javascript libraries like [Backbone.js 1.1.2](http://backbonejs.org/#) are used, primarily for the search function.
 
-###Service dependencies
+### Service dependencies
 * [SendGrid](http://sendgrid.com/) is used for all email notifications about requests.
 * [Akismet](http://akismet.com/) is used as a spam filter.
 * [Captcha](http://www.captcha.net/) is used to allow requesters to override the spam filter if necessary.
 * [Mozilla Persona](https://login.persona.org/) is used to manage user authentication and password management.
 
-###Feature backlog
+### Feature backlog
 Issues and feature backlog are tracked through [GitHub issues](https://github.com/codeforamerica/recordtrac/issues).
 
-###Developer documentation
+### Developer documentation
 * [Browse full source code on GitHub](https://github.com/codeforamerica/recordtrac)
 * [Technical docs](http://codeforamerica.github.io/recordtrac/docs/2.0.0/technical-docs.html)
 
-##How to use RecordTrac... as a requester
+## How to use RecordTrac... as a requester
 * [Search for a record](/docs/requester.md)
 * [Make a new request](/docs/requester.md#make-a-request)
 
-##How to use RecordTrac... as an agency employee
+## How to use RecordTrac... as an agency employee
 * [Search for a record](/docs/responder.md)
 * [Manage your request list](/docs/responder.md#manage-your-request-list)
 * [Make a new request](/docs/responder.md#make-a-new-request)

--- a/docs/redeploy.md
+++ b/docs/redeploy.md
@@ -1,4 +1,4 @@
-#How to create a new RecordTrac app for your agency
+# How to create a new RecordTrac app for your agency
 
 
 ## Groundwork

--- a/docs/requester.md
+++ b/docs/requester.md
@@ -76,12 +76,12 @@ A requester can respond to a question asked by an agency employee. This field on
 
 ## Follow and unfollow requests
 
-###Follow someone else's request
+### Follow someone else's request
 ![subscribe](/docs/images/subscribe.png "subscribe")
 
 If an individual is interested in the outcome of a particular request, they can subscribe to a request. They will receive email updates every time a response is added to the particular request and when it's closed.
 
-###Unfollow a request
+### Unfollow a request
 To remove yourself from following a particular request, select the "unfollow this request" option in the email notification you received when you followed the request.
 
 ![unsubscribe](/docs/images/unsubscribe.png "unsubscribe")


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
